### PR TITLE
use a class for buttons-under instead of an id

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ function start() {
     /* add "next question" button to each row except the last row*/
     for (row of app.rows) {
         var div = document.createElement("div");
-        div.id = "buttons-under"
+        div.className = "buttons-under"
         let next_question = `<button class="next-question"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" focusable="false" width="1.5em" height="1.5em" style="vertical-align: -0.375em;-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);margin: 0 0 0 -.3em;" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><path d="M16.707 13.293a.999.999 0 0 0-1.414 0L13 15.586V8a1 1 0 1 0-2 0v7.586l-2.293-2.293a.999.999 0 1 0-1.414 1.414L12 19.414l4.707-4.707a.999.999 0 0 0 0-1.414z" fill="white"></path></svg>next question</button>`
         let learned_something = ` <button class="learned-something">I learned something! <span class="star">★</span></button>`
         if (row === app.rows[app.rows.length-1]) {

--- a/style.css
+++ b/style.css
@@ -72,13 +72,13 @@ pre {
     position: relative;
 }
 
-#buttons-under {
+.buttons-under {
     width: 100%;
     text-align: right;
     padding-bottom: 1em;
 }
 
-#buttons-under button {
+.buttons-under button {
     visibility: hidden;
     font-size: 0.9em;
     line-height: 1.8em;
@@ -86,7 +86,7 @@ pre {
     margin-top: .2em;
 }
 
-#buttons-under button.learned-something {
+.buttons-under button.learned-something {
     margin-right: 1em;
 }
 
@@ -99,19 +99,19 @@ pre {
     color: yellow;
 }
 
-.row.question-revealed #buttons-under button {
+.row.question-revealed .buttons-under button {
     visibility: visible;
 }
 
-.row.done.question-revealed #buttons-under .next-question {
+.row.done.question-revealed .buttons-under .next-question {
     visibility: hidden;
 }
 
-.all-revealed #buttons-under button.learned-something {
+.all-revealed .buttons-under button.learned-something {
     visibility: visible;
 }
 
-.all-revealed .row.question-revealed #buttons-under button.next-question {
+.all-revealed .row.question-revealed .buttons-under button.next-question {
     visibility: hidden;
 }
 


### PR DESCRIPTION
Since each new button group gets this id currently, it creates a bunch of
non-unique id's in the html, which could be an issue.

![non-unique id attributes](https://user-images.githubusercontent.com/5070516/85382885-4ee9df00-b537-11ea-8d31-594a5c6320e0.png)

This commit uses a class instead of an id.